### PR TITLE
Bump httpclient from 4.5 to 4.5.13 in /tfs

### DIFF
--- a/tfs/pom.xml
+++ b/tfs/pom.xml
@@ -266,7 +266,7 @@
     <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.5.13</version>
+        <version>4.5.14</version>
         <type>jar</type>
     </dependency>
     <dependency>


### PR DESCRIPTION
Bumps httpclient from 4.5 to 4.5.13.

---
updated-dependencies:
- dependency-name: org.apache.httpcomponents:httpclient
  dependency-type: direct:production
...

Signed-off-by: dependabot[bot] <support@github.com>